### PR TITLE
Implement dasharray and dashoffset params

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ By default it's a white material of width 1 unit.
 * ```alphaTest``` - cutoff value from 0 to 1
 * ```dashArray``` - the length and space between dashes. (0 - no dash)
 * ```dashOffset``` - defines the location where the dash will begin. Ideal to animate the line.
+* ```dashRatio``` - defines the ratio between that is visible or not (0 - more visible, 1 - more invisible).
 * ```resolution``` - ```THREE.Vector2``` specifying the canvas size (REQUIRED)
 * ```sizeAttenuation``` - makes the line width constant regardless distance (1 unit is 1px on screen) (0 - attenuate, 1 - don't attenuate)
 * ```lineWidth``` - float defining width (if ```sizeAttenuation``` is true, it's world units; else is screen pixels)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ By default it's a white material of width 1 unit.
 * ```color``` - ```THREE.Color``` to paint the line width, or tint the texture with
 * ```opacity``` - alpha value from 0 to 1 (requires ```transparent``` set to ```true```)
 * ```alphaTest``` - cutoff value from 0 to 1
-* ```dashArray``` - THREE.Vector2 to define the dashing (NOT IMPLEMENTED YET)
+* ```dashArray``` - the length and space between dashes. (0 - no dash)
+* ```dashOffset``` - defines the location where the dash will begin. Ideal to animate the line.
 * ```resolution``` - ```THREE.Vector2``` specifying the canvas size (REQUIRED)
 * ```sizeAttenuation``` - makes the line width constant regardless distance (1 unit is 1px on screen) (0 - attenuate, 1 - don't attenuate)
 * ```lineWidth``` - float defining width (if ```sizeAttenuation``` is true, it's world units; else is screen pixels)
@@ -112,7 +113,6 @@ scene.add( mesh );
 
 * Better miters
 * Proper sizes
-* Support for dashArray
 
 ### Support ###
 

--- a/demo/js/main.js
+++ b/demo/js/main.js
@@ -23,6 +23,8 @@ var Params = function() {
 	this.circles = false;
 	this.amount = 100;
 	this.lineWidth = 10;
+  this.dashArray = 0;
+  this.dashOffset = 0;
 	this.taper = 'parabolic';
 	this.strokes = false;
 	this.sizeAttenuation = false;
@@ -30,7 +32,8 @@ var Params = function() {
 	this.spread = false;
 	this.autoRotate = true;
 	this.autoUpdate = true;
-    this.animateVisibility=false;
+  this.animateVisibility = false;
+  this.animateDashOffset = false;
 	this.update = function() {
 		clearLines();
 		createLines();
@@ -53,6 +56,7 @@ window.addEventListener( 'load', function() {
 	gui.add( params, 'circles' ).onChange( update );
 	gui.add( params, 'amount', 1, 1000 ).onChange( update );
 	gui.add( params, 'lineWidth', 1, 20 ).onChange( update );
+	gui.add( params, 'dashArray', 0, 1 ).onChange( update );
 	gui.add( params, 'taper', [ 'none', 'linear', 'parabolic', 'wavy' ] ).onChange( update );
 	gui.add( params, 'strokes' ).onChange( update );
 	gui.add( params, 'sizeAttenuation' ).onChange( update );
@@ -61,7 +65,8 @@ window.addEventListener( 'load', function() {
 	gui.add( params, 'animateWidth' );
 	gui.add( params, 'spread' );
 	gui.add( params, 'autoRotate' );
-    gui.add( params, 'animateVisibility' );
+  gui.add( params, 'animateVisibility' );
+  gui.add( params, 'animateDashOffset' );
 
 	var loader = new THREE.TextureLoader();
 	loader.load( 'assets/stroke.png', function( texture ) {
@@ -156,7 +161,8 @@ function makeLine( geo ) {
 		useMap: params.strokes,
 		color: new THREE.Color( colors[ ~~Maf.randomInRange( 0, colors.length ) ] ),
 		opacity: 1,//params.strokes ? .5 : 1,
-		dashArray: new THREE.Vector2( 10, 5 ),
+    dashArray: params.dashArray,
+    dashOffset: params.dashOffset,
 		resolution: resolution,
 		sizeAttenuation: params.sizeAttenuation,
 		lineWidth: params.lineWidth,
@@ -251,6 +257,7 @@ function render(time) {
 		if( params.animateWidth ) l.material.uniforms.lineWidth.value = params.lineWidth * ( 1 + .5 * Math.sin( 5 * t + i ) );
 		if( params.autoRotate ) l.rotation.y += .125 * delta;
       l.material.uniforms.visibility.value= params.animateVisibility ? (time/3000) % 1.0 : 1.0;
+      l.material.uniforms.dashOffset.value -= params.animateDashOffset ? 0.01 : 0;
 	} );
 
 	renderer.render( scene, camera );

--- a/demo/js/main.js
+++ b/demo/js/main.js
@@ -23,8 +23,9 @@ var Params = function() {
 	this.circles = false;
 	this.amount = 100;
 	this.lineWidth = 10;
-  this.dashArray = 0;
-  this.dashOffset = 0;
+	this.dashArray = 0.6;
+	this.dashOffset = 0;
+	this.dashRatio = 0.5;
 	this.taper = 'parabolic';
 	this.strokes = false;
 	this.sizeAttenuation = false;
@@ -32,8 +33,8 @@ var Params = function() {
 	this.spread = false;
 	this.autoRotate = true;
 	this.autoUpdate = true;
-  this.animateVisibility = false;
-  this.animateDashOffset = false;
+	this.animateVisibility = false;
+	this.animateDashOffset = false;
 	this.update = function() {
 		clearLines();
 		createLines();
@@ -56,7 +57,8 @@ window.addEventListener( 'load', function() {
 	gui.add( params, 'circles' ).onChange( update );
 	gui.add( params, 'amount', 1, 1000 ).onChange( update );
 	gui.add( params, 'lineWidth', 1, 20 ).onChange( update );
-	gui.add( params, 'dashArray', 0, 1 ).onChange( update );
+	gui.add( params, 'dashArray', 0, 3 ).onChange( update );
+	gui.add( params, 'dashRatio', 0, 1 ).onChange( update );
 	gui.add( params, 'taper', [ 'none', 'linear', 'parabolic', 'wavy' ] ).onChange( update );
 	gui.add( params, 'strokes' ).onChange( update );
 	gui.add( params, 'sizeAttenuation' ).onChange( update );
@@ -65,8 +67,8 @@ window.addEventListener( 'load', function() {
 	gui.add( params, 'animateWidth' );
 	gui.add( params, 'spread' );
 	gui.add( params, 'autoRotate' );
-  gui.add( params, 'animateVisibility' );
-  gui.add( params, 'animateDashOffset' );
+	gui.add( params, 'animateVisibility' );
+	gui.add( params, 'animateDashOffset' );
 
 	var loader = new THREE.TextureLoader();
 	loader.load( 'assets/stroke.png', function( texture ) {
@@ -161,8 +163,9 @@ function makeLine( geo ) {
 		useMap: params.strokes,
 		color: new THREE.Color( colors[ ~~Maf.randomInRange( 0, colors.length ) ] ),
 		opacity: 1,//params.strokes ? .5 : 1,
-    dashArray: params.dashArray,
-    dashOffset: params.dashOffset,
+		dashArray: params.dashArray,
+		dashOffset: params.dashOffset,
+		dashRatio: params.dashRatio,
 		resolution: resolution,
 		sizeAttenuation: params.sizeAttenuation,
 		lineWidth: params.lineWidth,
@@ -256,8 +259,8 @@ function render(time) {
 	lines.forEach( function( l, i ) {
 		if( params.animateWidth ) l.material.uniforms.lineWidth.value = params.lineWidth * ( 1 + .5 * Math.sin( 5 * t + i ) );
 		if( params.autoRotate ) l.rotation.y += .125 * delta;
-      l.material.uniforms.visibility.value= params.animateVisibility ? (time/3000) % 1.0 : 1.0;
-      l.material.uniforms.dashOffset.value -= params.animateDashOffset ? 0.01 : 0;
+			l.material.uniforms.visibility.value= params.animateVisibility ? (time/3000) % 1.0 : 1.0;
+			l.material.uniforms.dashOffset.value -= params.animateDashOffset ? 0.01 : 0;
 	} );
 
 	renderer.render( scene, camera );

--- a/src/THREE.MeshLine.js
+++ b/src/THREE.MeshLine.js
@@ -338,7 +338,8 @@ function MeshLineMaterial( parameters ) {
 'uniform float useMap;',
 'uniform float useAlphaMap;',
 'uniform float useDash;',
-'uniform vec2 dashArray;',
+'uniform float dashArray;',
+'uniform float dashOffset;',
 'uniform float visibility;',
 'uniform float alphaTest;',
 'uniform vec2 repeat;',
@@ -352,12 +353,12 @@ function MeshLineMaterial( parameters ) {
 '    vec4 c = vColor;',
 '    if( useMap == 1. ) c *= texture2D( map, vUV * repeat );',
 '    if( useAlphaMap == 1. ) c.a *= texture2D( alphaMap, vUV * repeat ).a;',
-'	 if( c.a < alphaTest ) discard;',
-'	 if( useDash == 1. ){',
-'	 	 ',
-'	 }',
+'    if( c.a < alphaTest ) discard;',
+'    if( useDash == 1. ){',
+'        c.a *= ceil(mod(vCounters + dashOffset, (dashArray)) - (dashArray * .5));',
+'    }',
 '    gl_FragColor = c;',
-'	 gl_FragColor.a *= step(vCounters,visibility);',
+'    gl_FragColor.a *= step(vCounters, visibility);',
 '}' ];
 
 	function check( v, d ) {
@@ -380,8 +381,9 @@ function MeshLineMaterial( parameters ) {
 	this.sizeAttenuation = check( parameters.sizeAttenuation, 1 );
 	this.near = check( parameters.near, 1 );
 	this.far = check( parameters.far, 1 );
-	this.dashArray = check( parameters.dashArray, [] );
-	this.useDash = ( this.dashArray !== [] ) ? 1 : 0;
+	this.dashArray = check( parameters.dashArray, 0 );
+	this.dashOffset = check( parameters.dashOffset, 0 );
+	this.useDash = ( this.dashArray !== 0 ) ? 1 : 0;
 	this.visibility = check( parameters.visibility, 1 );
 	this.alphaTest = check( parameters.alphaTest, 0 );
 	this.repeat = check( parameters.repeat, new THREE.Vector2( 1, 1 ) );
@@ -399,7 +401,8 @@ function MeshLineMaterial( parameters ) {
 			sizeAttenuation: { type: 'f', value: this.sizeAttenuation },
 			near: { type: 'f', value: this.near },
 			far: { type: 'f', value: this.far },
-			dashArray: { type: 'v2', value: new THREE.Vector2( this.dashArray[ 0 ], this.dashArray[ 1 ] ) },
+			dashArray: { type: 'f', value: this.dashArray },
+			dashOffset: { type: 'f', value: this.dashOffset },
 			useDash: { type: 'f', value: this.useDash },
 			visibility: {type: 'f', value: this.visibility},
 			alphaTest: {type: 'f', value: this.alphaTest},
@@ -421,6 +424,7 @@ function MeshLineMaterial( parameters ) {
 	delete parameters.near;
 	delete parameters.far;
 	delete parameters.dashArray;
+	delete parameters.dashOffset;
 	delete parameters.visibility;
 	delete parameters.alphaTest;
 	delete parameters.repeat;
@@ -474,4 +478,3 @@ else {
 }
 
 }).call(this);
-

--- a/src/THREE.MeshLine.js
+++ b/src/THREE.MeshLine.js
@@ -340,6 +340,7 @@ function MeshLineMaterial( parameters ) {
 'uniform float useDash;',
 'uniform float dashArray;',
 'uniform float dashOffset;',
+'uniform float dashRatio;',
 'uniform float visibility;',
 'uniform float alphaTest;',
 'uniform vec2 repeat;',
@@ -355,7 +356,7 @@ function MeshLineMaterial( parameters ) {
 '    if( useAlphaMap == 1. ) c.a *= texture2D( alphaMap, vUV * repeat ).a;',
 '    if( c.a < alphaTest ) discard;',
 '    if( useDash == 1. ){',
-'        c.a *= ceil(mod(vCounters + dashOffset, (dashArray)) - (dashArray * .5));',
+'        c.a *= ceil(mod(vCounters + dashOffset, dashArray) - (dashArray * dashRatio));',
 '    }',
 '    gl_FragColor = c;',
 '    gl_FragColor.a *= step(vCounters, visibility);',
@@ -383,6 +384,7 @@ function MeshLineMaterial( parameters ) {
 	this.far = check( parameters.far, 1 );
 	this.dashArray = check( parameters.dashArray, 0 );
 	this.dashOffset = check( parameters.dashOffset, 0 );
+	this.dashRatio = check( parameters.dashRatio, 0.5 );
 	this.useDash = ( this.dashArray !== 0 ) ? 1 : 0;
 	this.visibility = check( parameters.visibility, 1 );
 	this.alphaTest = check( parameters.alphaTest, 0 );
@@ -403,6 +405,7 @@ function MeshLineMaterial( parameters ) {
 			far: { type: 'f', value: this.far },
 			dashArray: { type: 'f', value: this.dashArray },
 			dashOffset: { type: 'f', value: this.dashOffset },
+			dashRatio: { type: 'f', value: this.dashRatio },
 			useDash: { type: 'f', value: this.useDash },
 			visibility: {type: 'f', value: this.visibility},
 			alphaTest: {type: 'f', value: this.alphaTest},
@@ -425,6 +428,7 @@ function MeshLineMaterial( parameters ) {
 	delete parameters.far;
 	delete parameters.dashArray;
 	delete parameters.dashOffset;
+	delete parameters.dashRatio;
 	delete parameters.visibility;
 	delete parameters.alphaTest;
 	delete parameters.repeat;
@@ -456,6 +460,8 @@ MeshLineMaterial.prototype.copy = function ( source ) {
 	this.near = source.near;
 	this.far = source.far;
 	this.dashArray.copy( source.dashArray );
+	this.dashOffset.copy( source.dashOffset );
+	this.dashRatio.copy( source.dashRatio );
 	this.useDash = source.useDash;
 	this.visibility = source.visibility;
 	this.alphaTest = source.alphaTest;


### PR DESCRIPTION
Hi, 

I have implemented two new parameters for the `MeshLineMaterial` to animate the mesh lines like we can do with the SVG strokes (see: [SVG line animation works](https://css-tricks.com/svg-line-animation-works/))

- `dasharray`: a float which defines the length and space between dashes. (0 by default to have no dash)
- `dashOffset`: a float to determine the location of the dash. Ideal to animate the stroke when it is incremented.

I also added in the main demo (`demo/js/main.js`) GUI parameters `dashArray` and `animateDashOffset` to manipulate and test them.

Finally, I updated the `README.md` to define the new parameters and remove the `Support for dashArray` of the TODO list.

