### PR TITLE
Standardize the MeshLineMaterial, support fog and logarithmicDepthBuffer.

### DIFF
--- a/src/THREE.MeshLine.js
+++ b/src/THREE.MeshLine.js
@@ -243,210 +243,343 @@ MeshLine.prototype.advance = function(position) {
 
 };
 
+/**
+ * * *******************
+ * * Material
+ * * *******************
+ */
+THREE.ShaderChunk[ 'meshline_vert' ] = [
+	'precision highp float;',
+	'',
+	'attribute vec3 position;',
+	'attribute vec3 previous;',
+	'attribute vec3 next;',
+	'attribute float side;',
+	'attribute float width;',
+	'attribute vec2 uv;',
+	'attribute float counters;',
+	'',
+	'uniform mat4 projectionMatrix;',
+	'uniform mat4 modelViewMatrix;',
+	'uniform vec2 resolution;',
+	'uniform float lineWidth;',
+	'uniform vec3 color;',
+	'uniform float opacity;',
+	'uniform float near;',
+	'uniform float far;',
+	'uniform float sizeAttenuation;',
+	'',
+	'varying vec2 vUV;',
+	'varying vec4 vColor;',
+	'varying float vCounters;',
+	'',
+	'vec2 fix( vec4 i, float aspect ) {',
+	'',
+	'    vec2 res = i.xy / i.w;',
+	'    res.x *= aspect;',
+	'	 vCounters = counters;',
+	'    return res;',
+	'',
+	'}',
+	'',
+	'void main() {',
+	'',
+	'    float aspect = resolution.x / resolution.y;',
+	'	 float pixelWidthRatio = 1. / (resolution.x * projectionMatrix[0][0]);',
+	'',
+	'    vColor = vec4( color, opacity );',
+	'    vUV = uv;',
+	'',
+	'    mat4 m = projectionMatrix * modelViewMatrix;',
+	'    vec4 finalPosition = m * vec4( position, 1.0 );',
+	'    vec4 prevPos = m * vec4( previous, 1.0 );',
+	'    vec4 nextPos = m * vec4( next, 1.0 );',
+	'',
+	'    vec2 currentP = fix( finalPosition, aspect );',
+	'    vec2 prevP = fix( prevPos, aspect );',
+	'    vec2 nextP = fix( nextPos, aspect );',
+	'',
+	'	 float pixelWidth = finalPosition.w * pixelWidthRatio;',
+	'    float w = 1.8 * pixelWidth * lineWidth * width;',
+	'',
+	'    if( sizeAttenuation == 1. ) {',
+	'        w = 1.8 * lineWidth * width;',
+	'    }',
+	'',
+	'    vec2 dir;',
+	'    if( nextP == currentP ) dir = normalize( currentP - prevP );',
+	'    else if( prevP == currentP ) dir = normalize( nextP - currentP );',
+	'    else {',
+	'        vec2 dir1 = normalize( currentP - prevP );',
+	'        vec2 dir2 = normalize( nextP - currentP );',
+	'        dir = normalize( dir1 + dir2 );',
+	'',
+	'        vec2 perp = vec2( -dir1.y, dir1.x );',
+	'        vec2 miter = vec2( -dir.y, dir.x );',
+	'        //w = clamp( w / dot( miter, perp ), 0., 4. * lineWidth * width );',
+	'',
+	'    }',
+	'',
+	'    //vec2 normal = ( cross( vec3( dir, 0. ), vec3( 0., 0., 1. ) ) ).xy;',
+	'    vec2 normal = vec2( -dir.y, dir.x );',
+	'    normal.x /= aspect;',
+	'    normal *= .5 * w;',
+	'',
+	'    vec4 offset = vec4( normal * side, 0.0, 1.0 );',
+	'    finalPosition.xy += offset.xy;',
+	'',
+	'    gl_Position = finalPosition;',
+	'',
+	'}'
+].join( '\r\n' );
+
+THREE.ShaderChunk[ 'meshline_frag' ] = [
+	'#extension GL_OES_standard_derivatives : enable',
+	'precision mediump float;',
+	'',
+	'uniform sampler2D map;',
+	'uniform sampler2D alphaMap;',
+	'uniform float useMap;',
+	'uniform float useAlphaMap;',
+	'uniform float useDash;',
+	'uniform float dashArray;',
+	'uniform float dashOffset;',
+	'uniform float dashRatio;',
+	'uniform float visibility;',
+	'uniform float alphaTest;',
+	'uniform vec2 repeat;',
+	'',
+	'varying vec2 vUV;',
+	'varying vec4 vColor;',
+	'varying float vCounters;',
+	'',
+	'void main() {',
+	'',
+	'    vec4 c = vColor;',
+	'    if( useMap == 1. ) c *= texture2D( map, vUV * repeat );',
+	'    if( useAlphaMap == 1. ) c.a *= texture2D( alphaMap, vUV * repeat ).a;',
+	'    if( c.a < alphaTest ) discard;',
+	'    if( useDash == 1. ){',
+	'        c.a *= ceil(mod(vCounters + dashOffset, dashArray) - (dashArray * dashRatio));',
+	'    }',
+	'    gl_FragColor = c;',
+	'    gl_FragColor.a *= step(vCounters, visibility);',
+	'}'
+].join( '\r\n' );
+
 function MeshLineMaterial( parameters ) {
 
-	var vertexShaderSource = [
-'precision highp float;',
-'',
-'attribute vec3 position;',
-'attribute vec3 previous;',
-'attribute vec3 next;',
-'attribute float side;',
-'attribute float width;',
-'attribute vec2 uv;',
-'attribute float counters;',
-'',
-'uniform mat4 projectionMatrix;',
-'uniform mat4 modelViewMatrix;',
-'uniform vec2 resolution;',
-'uniform float lineWidth;',
-'uniform vec3 color;',
-'uniform float opacity;',
-'uniform float near;',
-'uniform float far;',
-'uniform float sizeAttenuation;',
-'',
-'varying vec2 vUV;',
-'varying vec4 vColor;',
-'varying float vCounters;',
-'',
-'vec2 fix( vec4 i, float aspect ) {',
-'',
-'    vec2 res = i.xy / i.w;',
-'    res.x *= aspect;',
-'	 vCounters = counters;',
-'    return res;',
-'',
-'}',
-'',
-'void main() {',
-'',
-'    float aspect = resolution.x / resolution.y;',
-'	 float pixelWidthRatio = 1. / (resolution.x * projectionMatrix[0][0]);',
-'',
-'    vColor = vec4( color, opacity );',
-'    vUV = uv;',
-'',
-'    mat4 m = projectionMatrix * modelViewMatrix;',
-'    vec4 finalPosition = m * vec4( position, 1.0 );',
-'    vec4 prevPos = m * vec4( previous, 1.0 );',
-'    vec4 nextPos = m * vec4( next, 1.0 );',
-'',
-'    vec2 currentP = fix( finalPosition, aspect );',
-'    vec2 prevP = fix( prevPos, aspect );',
-'    vec2 nextP = fix( nextPos, aspect );',
-'',
-'	 float pixelWidth = finalPosition.w * pixelWidthRatio;',
-'    float w = 1.8 * pixelWidth * lineWidth * width;',
-'',
-'    if( sizeAttenuation == 1. ) {',
-'        w = 1.8 * lineWidth * width;',
-'    }',
-'',
-'    vec2 dir;',
-'    if( nextP == currentP ) dir = normalize( currentP - prevP );',
-'    else if( prevP == currentP ) dir = normalize( nextP - currentP );',
-'    else {',
-'        vec2 dir1 = normalize( currentP - prevP );',
-'        vec2 dir2 = normalize( nextP - currentP );',
-'        dir = normalize( dir1 + dir2 );',
-'',
-'        vec2 perp = vec2( -dir1.y, dir1.x );',
-'        vec2 miter = vec2( -dir.y, dir.x );',
-'        //w = clamp( w / dot( miter, perp ), 0., 4. * lineWidth * width );',
-'',
-'    }',
-'',
-'    //vec2 normal = ( cross( vec3( dir, 0. ), vec3( 0., 0., 1. ) ) ).xy;',
-'    vec2 normal = vec2( -dir.y, dir.x );',
-'    normal.x /= aspect;',
-'    normal *= .5 * w;',
-'',
-'    vec4 offset = vec4( normal * side, 0.0, 1.0 );',
-'    finalPosition.xy += offset.xy;',
-'',
-'    gl_Position = finalPosition;',
-'',
-'}' ];
-
-	var fragmentShaderSource = [
-		'#extension GL_OES_standard_derivatives : enable',
-'precision mediump float;',
-'',
-'uniform sampler2D map;',
-'uniform sampler2D alphaMap;',
-'uniform float useMap;',
-'uniform float useAlphaMap;',
-'uniform float useDash;',
-'uniform float dashArray;',
-'uniform float dashOffset;',
-'uniform float dashRatio;',
-'uniform float visibility;',
-'uniform float alphaTest;',
-'uniform vec2 repeat;',
-'',
-'varying vec2 vUV;',
-'varying vec4 vColor;',
-'varying float vCounters;',
-'',
-'void main() {',
-'',
-'    vec4 c = vColor;',
-'    if( useMap == 1. ) c *= texture2D( map, vUV * repeat );',
-'    if( useAlphaMap == 1. ) c.a *= texture2D( alphaMap, vUV * repeat ).a;',
-'    if( c.a < alphaTest ) discard;',
-'    if( useDash == 1. ){',
-'        c.a *= ceil(mod(vCounters + dashOffset, dashArray) - (dashArray * dashRatio));',
-'    }',
-'    gl_FragColor = c;',
-'    gl_FragColor.a *= step(vCounters, visibility);',
-'}' ];
-
-	function check( v, d ) {
-		if( v === undefined ) return d;
-		return v;
-	}
-
-	THREE.Material.call( this );
-
-	parameters = parameters || {};
-
-	this.lineWidth = check( parameters.lineWidth, 1 );
-	this.map = check( parameters.map, null );
-	this.useMap = check( parameters.useMap, 0 );
-	this.alphaMap = check( parameters.alphaMap, null );
-	this.useAlphaMap = check( parameters.useAlphaMap, 0 );
-	this.color = check( parameters.color, new THREE.Color( 0xffffff ) );
-	this.opacity = check( parameters.opacity, 1 );
-	this.resolution = check( parameters.resolution, new THREE.Vector2( 1, 1 ) );
-	this.sizeAttenuation = check( parameters.sizeAttenuation, 1 );
-	this.near = check( parameters.near, 1 );
-	this.far = check( parameters.far, 1 );
-	this.dashArray = check( parameters.dashArray, 0 );
-	this.dashOffset = check( parameters.dashOffset, 0 );
-	this.dashRatio = check( parameters.dashRatio, 0.5 );
-	this.useDash = ( this.dashArray !== 0 ) ? 1 : 0;
-	this.visibility = check( parameters.visibility, 1 );
-	this.alphaTest = check( parameters.alphaTest, 0 );
-	this.repeat = check( parameters.repeat, new THREE.Vector2( 1, 1 ) );
-
-	var material = new THREE.RawShaderMaterial( {
-		uniforms:{
-			lineWidth: { type: 'f', value: this.lineWidth },
-			map: { type: 't', value: this.map },
-			useMap: { type: 'f', value: this.useMap },
-			alphaMap: { type: 't', value: this.alphaMap },
-			useAlphaMap: { type: 'f', value: this.useAlphaMap },
-			color: { type: 'c', value: this.color },
-			opacity: { type: 'f', value: this.opacity },
-			resolution: { type: 'v2', value: this.resolution },
-			sizeAttenuation: { type: 'f', value: this.sizeAttenuation },
-			near: { type: 'f', value: this.near },
-			far: { type: 'f', value: this.far },
-			dashArray: { type: 'f', value: this.dashArray },
-			dashOffset: { type: 'f', value: this.dashOffset },
-			dashRatio: { type: 'f', value: this.dashRatio },
-			useDash: { type: 'f', value: this.useDash },
-			visibility: {type: 'f', value: this.visibility},
-			alphaTest: {type: 'f', value: this.alphaTest},
-			repeat: { type: 'v2', value: this.repeat }
+	/**
+	 * TODO: merge the UniformShaders & UniformsLibs.already existing
+	 * THREE.UniformsLib.common,
+	 * THREE.UniformsLib.fog,
+	 */
+	THREE.RawShaderMaterial.call( this, {
+		uniforms: {
+			lineWidth: { value: 1 },
+			map: { value: null },
+			useMap: { value: 0 },
+			alphaMap: { value: null },
+			useAlphaMap: { value: 0 },
+			color: { value: new THREE.Color( 0xffffff ) },
+			opacity: { value: 1 },
+			resolution: { value: new THREE.Vector2( 1, 1 ) },
+			sizeAttenuation: { value: 1 },
+			near: { value: 1 },
+			far: { value: 1 },
+			dashArray: { value: 0 },
+			dashOffset: { value: 0 },
+			dashRatio: { value: 0.5 },
+			useDash: { value: 0 },
+			visibility: {value: 1 },
+			alphaTest: {value: 0 },
+			repeat: { value: new THREE.Vector2( 1, 1 ) }
 		},
-		vertexShader: vertexShaderSource.join( '\r\n' ),
-		fragmentShader: fragmentShaderSource.join( '\r\n' )
+
+		vertexShader: THREE.ShaderChunk.meshline_vert,
+
+		fragmentShader: THREE.ShaderChunk.meshline_frag,
+
+	} );
+
+	this.type = 'MeshLineMaterial';
+
+	Object.defineProperties( this, {
+		lineWidth: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.lineWidth.value;
+			},
+			set: function ( value ) {
+				this.uniforms.lineWidth.value = value;
+			}
+		},
+		map: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.map.value;
+			},
+			set: function ( value ) {
+				this.uniforms.map.value = value;
+			}
+		},
+		useMap: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.useMap.value;
+			},
+			set: function ( value ) {
+				this.uniforms.useMap.value = value;
+			}
+		},
+		alphaMap: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.alphaMap.value;
+			},
+			set: function ( value ) {
+				this.uniforms.alphaMap.value = value;
+			}
+		},
+		useAlphaMap: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.useAlphaMap.value;
+			},
+			set: function ( value ) {
+				this.uniforms.useAlphaMap.value = value;
+			}
+		},
+		color: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.color.value;
+			},
+			set: function ( value ) {
+				this.uniforms.color.value = value;
+			}
+		},
+		opacity: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.opacity.value;
+			},
+			set: function ( value ) {
+				this.uniforms.opacity.value = value;
+			}
+		},
+		resolution: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.resolution.value;
+			},
+			set: function ( value ) {
+				this.uniforms.resolution.value.copy( value );
+			}
+		},
+		sizeAttenuation: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.sizeAttenuation.value;
+			},
+			set: function ( value ) {
+				this.uniforms.sizeAttenuation.value = value;
+			}
+		},
+		near: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.near.value;
+			},
+			set: function ( value ) {
+				this.uniforms.near.value = value;
+			}
+		},
+		far: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.far.value;
+			},
+			set: function ( value ) {
+				this.uniforms.far.value = value;
+			}
+		},
+		dashArray: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.dashArray.value;
+			},
+			set: function ( value ) {
+				this.uniforms.dashArray.value = value;
+			}
+		},
+		dashOffset: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.dashOffset.value;
+			},
+			set: function ( value ) {
+				this.uniforms.dashOffset.value = value;
+			}
+		},
+		dashRatio: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.dashRatio.value;
+			},
+			set: function ( value ) {
+				this.uniforms.dashRatio.value = value;
+			}
+		},
+		useDash: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.useDash.value;
+			},
+			set: function ( value ) {
+				this.uniforms.useDash.value = value;
+			}
+		},
+		visibility: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.visibility.value;
+			},
+			set: function ( value ) {
+				this.uniforms.visibility.value = value;
+			}
+		},
+		alphaTest: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.alphaTest.value;
+			},
+			set: function ( value ) {
+				this.uniforms.alphaTest.value = value;
+			}
+		},
+		repeat: {
+			enumerable: true,
+			get: function () {
+				return this.uniforms.repeat.value;
+			},
+			set: function ( value ) {
+				this.uniforms.repeat.value.copy( value );
+			}
+		},
 	});
 
-	delete parameters.lineWidth;
-	delete parameters.map;
-	delete parameters.useMap;
-	delete parameters.alphaMap;
-	delete parameters.useAlphaMap;
-	delete parameters.color;
-	delete parameters.opacity;
-	delete parameters.resolution;
-	delete parameters.sizeAttenuation;
-	delete parameters.near;
-	delete parameters.far;
-	delete parameters.dashArray;
-	delete parameters.dashOffset;
-	delete parameters.dashRatio;
-	delete parameters.visibility;
-	delete parameters.alphaTest;
-	delete parameters.repeat;
+	this.setValues( parameters );
+}
 
-	material.type = 'MeshLineMaterial';
-
-	material.setValues( parameters );
-
-	return material;
-
-};
-
-MeshLineMaterial.prototype = Object.create( THREE.Material.prototype );
+MeshLineMaterial.prototype = Object.create( THREE.RawShaderMaterial.prototype );
 MeshLineMaterial.prototype.constructor = MeshLineMaterial;
+
+MeshLineMaterial.prototype.isMeshLineMaterial = true;
 
 MeshLineMaterial.prototype.copy = function ( source ) {
 
-	THREE.Material.prototype.copy.call( this, source );
+	Material.prototype.copy.call( this, source );
 
 	this.lineWidth = source.lineWidth;
 	this.map = source.map;
@@ -468,7 +601,6 @@ MeshLineMaterial.prototype.copy = function ( source ) {
 	this.repeat.copy( source.repeat );
 
 	return this;
-
 };
 
 if( typeof exports !== 'undefined' ) {

--- a/src/THREE.MeshLine.js
+++ b/src/THREE.MeshLine.js
@@ -243,11 +243,6 @@ MeshLine.prototype.advance = function(position) {
 
 };
 
-/**
- * * *******************
- * * Material
- * * *******************
- */
 THREE.ShaderChunk[ 'meshline_vert' ] = [
 	'',
 	THREE.ShaderChunk.logdepthbuf_pars_vertex,
@@ -584,7 +579,7 @@ MeshLineMaterial.prototype.isMeshLineMaterial = true;
 
 MeshLineMaterial.prototype.copy = function ( source ) {
 
-	Material.prototype.copy.call( this, source );
+	THREE.ShaderMaterial.prototype.copy.call( this, source );
 
 	this.lineWidth = source.lineWidth;
 	this.map = source.map;
@@ -606,6 +601,7 @@ MeshLineMaterial.prototype.copy = function ( source ) {
 	this.repeat.copy( source.repeat );
 
 	return this;
+
 };
 
 if( typeof exports !== 'undefined' ) {


### PR DESCRIPTION
### This is a MINOR update !

I rewrote the structure of the `MeshLineMaterial` to standardize it closer to the others Three.Js materials but in avoid any breaking changes.
I confirm that did not change any props or the current shaders core too.
I just took advantage of this rewrote to add the support of the fog and the logarithmicDepthBuffer.

#### Details:

- I directly made it herited to a `ShaderMaterial` instead of a `Material` who returning a `RawShaderMaterial`. That allow to have the material properties dynamic and fix some user's issues who use them directly (#70, #71, #67).

- I updated the `RawShaderMaterial` to a `ShaderMaterial` to be more generic and enable the usage of the [WebGLProgram](https://threejs.org/docs/#api/en/renderers/webgl/WebGLProgram). The material can now detect automatically some rendering parameters.

- I included the `logdepthbuf_pars` & `fog_pars` to fix #65, #48 and #32 thank to the previous point. It should be easier to also include other supports  like the `tonemapping_pars`.

