### PR TITLE
Use latest Three.js API to set attributes

### DIFF
--- a/src/THREE.MeshLine.js
+++ b/src/THREE.MeshLine.js
@@ -334,13 +334,13 @@ MeshLine.prototype.process = function() {
 		this.attributes.index.needsUpdate = true;
 	}
 
-	this.geometry.addAttribute( 'position', this.attributes.position );
-	this.geometry.addAttribute( 'previous', this.attributes.previous );
-	this.geometry.addAttribute( 'next', this.attributes.next );
-	this.geometry.addAttribute( 'side', this.attributes.side );
-	this.geometry.addAttribute( 'width', this.attributes.width );
-	this.geometry.addAttribute( 'uv', this.attributes.uv );
-	this.geometry.addAttribute( 'counters', this.attributes.counters );
+	this.geometry.setAttribute( 'position', this.attributes.position );
+	this.geometry.setAttribute( 'previous', this.attributes.previous );
+	this.geometry.setAttribute( 'next', this.attributes.next );
+	this.geometry.setAttribute( 'side', this.attributes.side );
+	this.geometry.setAttribute( 'width', this.attributes.width );
+	this.geometry.setAttribute( 'uv', this.attributes.uv );
+	this.geometry.setAttribute( 'counters', this.attributes.counters );
 
 	this.geometry.setIndex( this.attributes.index );
 


### PR DESCRIPTION
When setting attributes with the `BufferGeometry.prototype.addAttribute`
method, Three.js currently warns:

> THREE.BufferGeometry: .addAttribute() has been renamed to .setAttribute().

This changes the related method calls to use the updated name.