### PR TITLE
Fixed counters attribute calculation

### DIFF
--- a/src/THREE.MeshLine.js
+++ b/src/THREE.MeshLine.js
@@ -106,7 +106,7 @@
 			// and is more performant
 			for (var j = 0; j < points.length; j++) {
 				var p = points[j];
-				var c = j / points.length;
+				var c = j / (points.length - 1)
 				this.positions.push(p.x, p.y, p.z);
 				this.positions.push(p.x, p.y, p.z);
 				this.counters.push(c);
@@ -114,7 +114,7 @@
 			}
 		} else {
 			for (var j = 0; j < points.length; j += 3) {
-				var c = j / points.length;
+				var c = j / (points.length - 1)
 				this.positions.push(points[j], points[j + 1], points[j + 2]);
 				this.positions.push(points[j], points[j + 1], points[j + 2]);
 				this.counters.push(c);


### PR DESCRIPTION
The counters attribute array made the dash calculations go wrong.
For example: a two-point line with a dashArray value of 0.5 would only give 1 dash instead of (1/0.5 =) 2.
(See plot of opacity/alpha value [here](https://jsfiddle.net/7ksj2u0r/).)
This altered counters calculation fixes that.