### PR TITLE
remove extra *projectionmatrix in vertex shader

### DIFF
--- a/src/THREE.MeshLine.js
+++ b/src/THREE.MeshLine.js
@@ -435,7 +435,6 @@
     '    //vec2 normal = ( cross( vec3( dir, 0. ), vec3( 0., 0., 1. ) ) ).xy;',
     '    vec4 normal = vec4( -dir.y, dir.x, 0., 1. );',
     '    normal.xy *= .5 * w;',
-    '    normal *= projectionMatrix;',
     '    if( sizeAttenuation == 0. ) {',
     '        normal.xy *= finalPosition.w;',
     '        normal.xy /= ( vec4( resolution, 0., 1. ) * projectionMatrix ).xy;',


### PR DESCRIPTION
`normal` is already computed in clip space so why is it projected again using the projection matrix? This creates incorrect thickness in general but especially for `sizeAttenuation` to work as expected. Am I missing something magic here?

could be related to these 
https://github.com/spite/THREE.MeshLine/issues/49
https://github.com/spite/THREE.MeshLine/issues/52
https://github.com/spite/THREE.MeshLine/issues/136
https://github.com/spite/THREE.MeshLine/issues/132

I also noticed strange behavior when scaling meshlines causin the thickness to be unpredictable. So there may be other issues in the shader, I ended up just doing the calculations in world space for consistent (in world space) line width since I wasn't able to guarantee it with this shader